### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,7 @@
 name: Ruff
 on: [ push, pull_request ]
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freinold/gliner-api/security/code-scanning/19](https://github.com/freinold/gliner-api/security/code-scanning/19)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow appears to perform linting using Ruff and does not modify the repository, the `contents: read` permission is sufficient. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
