### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,6 +1,7 @@
 name: Release and Build Docker Image
 permissions:
   contents: read
+  actions: write        # required by actions/cache to save new entries
   packages: write
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/freinold/gliner-api/security/code-scanning/1](https://github.com/freinold/gliner-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to the GitHub Container Registry.

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated workflow permissions for building and releasing Docker images to clarify access levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->