### PR TITLE
Metrics served on own port with option to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **Docker** and **Docker Compose** support.
 - **ONNX** inference support (including quantized models).
 - **API key** authentication (optional).
+- **Custom metrics port** and enable/disable option for Prometheus metrics.
 
 ---
 
@@ -96,6 +97,7 @@ uv run main.py --help
 | `--host`                | Host address                                              | `0.0.0.0`                                        |
 | `--port`                | Port                                                      | `8080`                                           |
 | `--metrics_enabled`     | Enable Prometheus metrics endpoint                        | `True`                                           |
+| `--metrics_port`        | Port for Prometheus metrics endpoint                      | `9090`                                           |
 | `--frontend_enabled`    | Enable Gradio frontend                                    | `True`                                           |
 
 [gliner-models]: https://huggingface.co/models?library=gliner&sort=trending
@@ -105,7 +107,7 @@ uv run main.py --help
 ## API & Frontend
 
 - **API docs:** `/docs` (Swagger UI), `/redoc`
-- **Prometheus metrics:** `/metrics` (if enabled)
+- **Prometheus metrics:** `/metrics` (if enabled, served on a separate port set with `--metrics-port`, default: 9090)
 - **Gradio frontend:** `/` (if enabled)
 
 ---

--- a/gliner_api/config.py
+++ b/gliner_api/config.py
@@ -51,6 +51,12 @@ class Config(BaseSettings):
         default=True,
         description="Whether to enable Prometheus metrics for the API. If enabled, metrics will be available at /metrics endpoint.",
     )
+    metrics_port: int = Field(
+        default=9090,
+        ge=1,
+        le=65535,
+        description="The port number for serving Prometheus metrics. This is only used if metrics_enabled is set to True.",
+    )
     frontend_enabled: bool = Field(
         default=True,
         description="Whether to enable the Gradio frontend for the API. If enabled, the frontend will be available at server root.",

--- a/gliner_api/config.py
+++ b/gliner_api/config.py
@@ -73,6 +73,8 @@ class Config(BaseSettings):
         yaml_file="config.yaml",
         yaml_file_encoding="utf-8",
         cli_parse_args=True,
+        cli_kebab_case=True,
+        cli_prog_name="gliner-api",
     )
 
     # Reorder settings sources to prioritize YAML config

--- a/gliner_api/metrics.py
+++ b/gliner_api/metrics.py
@@ -1,4 +1,4 @@
-from prometheus_client import Counter, Enum, Histogram, Info, make_asgi_app
+from prometheus_client import Counter, Enum, Histogram, Info
 
 from gliner_api.datamodel import InfoResponse
 
@@ -35,5 +35,3 @@ app_state_metric: Enum = Enum(
 
 # Observe info by using the InfoResponse model
 info_metric.info({k: str(v) for k, v in InfoResponse().model_dump().items()})
-
-metrics_app = make_asgi_app()


### PR DESCRIPTION
Closes #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Prometheus metrics endpoint to run on a separate, user-defined port via the new `--metrics-port` CLI option (default: 9090).

* **Documentation**
  * Updated the README to describe the new metrics port configuration feature, including details in the features list, CLI options table, and API & Frontend section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->