### PR TITLE
fix(frontend): set request host to localhost permanently to fix errors when app is bound to 0.0.0.0

### DIFF
--- a/gliner_api/frontend.py
+++ b/gliner_api/frontend.py
@@ -10,7 +10,7 @@ from gliner_api.config import Config, get_config
 
 config: Config = get_config()
 client: AsyncClient = AsyncClient(
-    base_url=f"http://{config.host}:{config.port}",
+    base_url=f"http://localhost:{config.port}",
     headers={"Authorization": f"Bearer {config.api_key}"} if config.api_key is not None else None,
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API client to always connect to the local machine for requests, using the configured port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->