### PR TITLE
conf(renovate): group minor+patch python dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,4 +17,12 @@
     enabled: true,
   },
   reviewers: ["freinold"],
+  packageRules: [
+    {
+      matchManagers: ["pep621"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "Python: non-major updates",
+      groupSlug: "python-non-major"
+    }
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,7 +10,6 @@
     ":separateMultipleMajorReleases", // separate major updates of dependencies into separate PRs
     ":timezone(Europe/Berlin)", // sets correct timezone for schedule based operations
     "security:openssf-scorecard", // show OpenSSF badge on pull requests to evaluate security health metrics for dependencies
-    ":automergePatch", // automerge minor & patch updates
   ],
   labels: ["renovate", "lifecycle"],
   lockFileMaintenance: {

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,17 @@
       matchManagers: ["pep621"],
       matchUpdateTypes: ["minor", "patch"],
       groupName: "Python: non-major updates",
-      groupSlug: "python-non-major"
-    }
-  ]
+      groupSlug: "python-non-major",
+    },
+    {
+      matchManagers: ["dockerfile"],
+      groupName: "Dockerfile base images",
+      groupSlug: "dockerfile-base-images",
+    },
+    {
+      matchManagers: ["github-actions"],
+      groupName: "GitHub Actions dependencies",
+      groupSlug: "github-actions",
+    },
+  ],
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added grouping rules for dependency automation: non-major Python updates (minor/patch) are now bundled as "Python: non-major updates" to reduce PR noise.
  * New groups consolidate Docker base image updates ("Dockerfile base images") and GitHub Actions dependency updates ("GitHub Actions dependencies").
  * Removed automatic merging for patch updates (automerge for patch releases disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->