### PR TITLE
feat: ipv6 support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ uv run main.py --help
 | `--default-entities`    | Default entities to detect                                | `['person', 'organization', 'location', 'date']` |
 | `--default-threshold`   | Default detection threshold                               | `0.5`                                            |
 | `--api-key`             | API key for authentication (if set, required in requests) | `null`                                           |
-| `--host`                | Host address                                              | `0.0.0.0`                                        |
+| `--host`                | Host address                                              | `""` (bind to all interfaces)                  |
 | `--port`                | Port                                                      | `8080`                                           |
 | `--metrics-enabled`     | Enable Prometheus metrics endpoint                        | `True`                                           |
 | `--metrics-port`        | Port for Prometheus metrics endpoint                      | `9090`                                           |

--- a/cpu.Dockerfile
+++ b/cpu.Dockerfile
@@ -82,4 +82,4 @@ USER appuser
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT ["python", "main.py"]
 
-CMD ["--host", "0.0.0.0", "--port", "8080"]
+CMD ["--host", "", "--port", "8080"]

--- a/example_configs/general.yaml
+++ b/example_configs/general.yaml
@@ -9,5 +9,5 @@ default_entities:
 - location
 - date
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/example_configs/general_onnx.yaml
+++ b/example_configs/general_onnx.yaml
@@ -11,5 +11,5 @@ default_entities:
 - location
 - date
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/example_configs/general_onnx_quantized.yaml
+++ b/example_configs/general_onnx_quantized.yaml
@@ -11,5 +11,5 @@ default_entities:
 - location
 - date
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/example_configs/medical.yaml
+++ b/example_configs/medical.yaml
@@ -22,5 +22,5 @@ default_entities:
 - treatment
 - virus
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/example_configs/pii+phi_quantized.yaml
+++ b/example_configs/pii+phi_quantized.yaml
@@ -42,5 +42,5 @@ default_entities:
 - treatment
 - virus
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/example_configs/pii.yaml
+++ b/example_configs/pii.yaml
@@ -28,5 +28,5 @@ default_entities:
 - vehicle identification number
 - zip code
 api_key: null
-host: "0.0.0.0"
+host: ""
 port: 8080

--- a/gliner_api/config.py
+++ b/gliner_api/config.py
@@ -38,7 +38,7 @@ class Config(BaseSettings):
         description="API key for authentication; if provided, each request needs to include it.",
     )
     host: str = Field(
-        default="0.0.0.0",
+        default="",
         description="The host address for serving the API.",
     )
     port: int = Field(

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -94,4 +94,4 @@ USER appuser
 # Reset the entrypoint, don't invoke `uv`
 ENTRYPOINT ["python", "main.py"]
 
-CMD ["--host", "0.0.0.0", "--port", "8080"]
+CMD ["--host", "", "--port", "8080"]

--- a/main.py
+++ b/main.py
@@ -16,15 +16,28 @@ def main() -> None:
     if config.metrics_enabled:
         if config.metrics_port == config.port:
             raise ValueError("Metrics port cannot be the same as API port. Please set a different port for metrics.")
-        prometheus_host = config.host if config.host != "" else "0.0.0.0"
-        metrics_server, metrics_thread = start_http_server(addr=prometheus_host, port=config.metrics_port)
-        logger.info(f"Prometheus metrics server started at http://{prometheus_host}:{config.metrics_port}")
+        if config.host == "":
+            # Dual stack: listen on both IPv4 and IPv6
+            ipv6_metrics_server, ipv6_metrics_thread = start_http_server(addr="::", port=config.metrics_port)
+            ipv4_metrics_server, ipv4_metrics_thread = start_http_server(addr="0.0.0.0", port=config.metrics_port)
+            logger.info(f"Prometheus metrics server started at http://[::]:{config.metrics_port} and http://0.0.0.0:{config.metrics_port}")
 
-        @app.on_event("shutdown")
-        async def close_metrics_server():
-            metrics_server.shutdown()
-            metrics_thread.join()
-            logger.info("Prometheus metrics server shutdown complete.")
+            @app.on_event("shutdown")
+            async def close_dual_metrics_server():
+                ipv6_metrics_server.shutdown()
+                ipv6_metrics_thread.join()
+                ipv4_metrics_server.shutdown()
+                ipv4_metrics_thread.join()
+                logger.info("Prometheus metrics server shutdown complete.")
+        else:
+            metrics_server, metrics_thread = start_http_server(addr=config.host, port=config.metrics_port)
+            logger.info(f"Prometheus metrics server started at http://{config.host}:{config.metrics_port}")
+
+            @app.on_event("shutdown")
+            async def close_metrics_server():
+                metrics_server.shutdown()
+                metrics_thread.join()
+                logger.info("Prometheus metrics server shutdown complete.")
 
     if config.frontend_enabled:
         from fastapi.staticfiles import StaticFiles

--- a/main.py
+++ b/main.py
@@ -16,8 +16,9 @@ def main() -> None:
     if config.metrics_enabled:
         if config.metrics_port == config.port:
             raise ValueError("Metrics port cannot be the same as API port. Please set a different port for metrics.")
-        metrics_server, metrics_thread = start_http_server(addr=config.host, port=config.metrics_port)
-        logger.info(f"Prometheus metrics server started at http://{config.host}:{config.metrics_port}")
+        prometheus_host = config.host if config.host != "" else "0.0.0.0"
+        metrics_server, metrics_thread = start_http_server(addr=prometheus_host, port=config.metrics_port)
+        logger.info(f"Prometheus metrics server started at http://{prometheus_host}:{config.metrics_port}")
 
         @app.on_event("shutdown")
         async def close_metrics_server():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI option to enable the Gradio frontend (default: enabled).

* **Documentation**
  * Clarified host binding in CLI docs: default shown as empty string with note “bind to all interfaces.”

* **Chores**
  * Updated default host to empty string across configs and container images to bind all interfaces.
  * Metrics server now starts dual-stack endpoints when host is empty (IPv6 and IPv4).
  * Removed two default entities (treatment, virus) from the medical example configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->